### PR TITLE
- Replace $this by static:: call in deleteByToken method

### DIFF
--- a/src/Watson/Autologin/Providers/EloquentAutologinProvider.php
+++ b/src/Watson/Autologin/Providers/EloquentAutologinProvider.php
@@ -41,7 +41,7 @@ class EloquentAutologinProvider extends Model implements AutologinInterface {
      */
     public static function deleteByToken($token)
     {
-        $this->findByToken($token)->delete();
+        static::findByToken($token)->delete();
     }
 
     /**


### PR DESCRIPTION
Found a minor error in EloquentAutologinProvider.
I know this is an unused method, but it was causing a warning in my IDE =)
