### PR TITLE
Fix redirection to home on invalid token

### DIFF
--- a/src/controllers/AutologinController.php
+++ b/src/controllers/AutologinController.php
@@ -46,7 +46,7 @@ class AutologinController extends Controller {
 		}
 
 		// Token was invalid, redirect back to the home page.
-		return Redirect::to(base_path());
+		return Redirect::to('/');
 	}
 
 }


### PR DESCRIPTION
Currently, when an invalid token is used, the redirection is supposedly done to the home page, but the function base_path() is used.
This function returns the server path (e.g. /var/www/laravel or /home/userx/my-site/) and not the URL path.
This resulting redirection produces a 404.

Using a simple "/" is sufficient for Laravel to redirect to the base URL of the install.
