### PR TITLE
Prevent error when trying to login a non-existent user.

### DIFF
--- a/src/Providers/AuthAuthenticationProvider.php
+++ b/src/Providers/AuthAuthenticationProvider.php
@@ -14,6 +14,12 @@ class AuthAuthenticationProvider implements AuthenticationInterface
 	 */
 	public function loginUsingId($userId)
 	{
+		$auth_provider = Auth::getProvider();
+		$user = $auth_provider->retrieveById($userId);
+		if (!$user)
+		{
+			return null;
+		}
 		return Auth::loginUsingId($userId);
 	}	
 }

--- a/src/controllers/AutologinController.php
+++ b/src/controllers/AutologinController.php
@@ -1,6 +1,7 @@
 <?php namespace Watson\Autologin;
 
 use Auth, Redirect;
+use Illuminate\Auth\UserInterface;
 use Illuminate\Routing\Controller;
 use Watson\Autologin\Interfaces\AuthenticationInterface;
 use Watson\Autologin\Interfaces\AutologinInterface;
@@ -40,9 +41,13 @@ class AutologinController extends Controller {
 		{
 			// Active token found, login the user and redirect to the
 			// intended path.
-			$this->authProvider->loginUsingId($autologin->getUserId());
+			$user = $this->authProvider->loginUsingId($autologin->getUserId());
 
-			return Redirect::to($autologin->getPath());
+			// The user has been found
+			if ($user instanceof UserInterface)
+			{
+				return Redirect::to($autologin->getPath());
+			}
 		}
 
 		// Token was invalid, redirect back to the home page.


### PR DESCRIPTION
If the user has been deleted between the autologin link generation and the link usage, this results in the following error and provoking a 500:
"Argument 1 passed to Illuminate\Auth\Guard::login() must implement interface Illuminate\Auth\UserInterface, null given, called in .../vendor/laravel/framework/src/Illuminate/Auth/Guard.php on line 462"

This modification suppresses the error and redirects the not-found user to the home page (same as invalid token) by first checking if the user exists (retrieveById) before trying to login.

A similar (simpler) modification could be done on SentryAuthenticationProvider but I don't have any environment to test it on.
