### PR TITLE
Fix warning for "undefined variable: user"

### DIFF
--- a/src/controllers/AutologinController.php
+++ b/src/controllers/AutologinController.php
@@ -40,12 +40,10 @@ class AutologinController extends Controller {
 		{
 			// Active token found, login the user and redirect to the
 			// intended path.
-			$user = $this->authProvider->loginUsingId($autologin->getUserId());
-		}
-
-		if ($user) 
-		{
-			return Redirect::to($autologin->getPath());
+			if ($user = $this->authProvider->loginUsingId($autologin->getUserId()))
+			{
+				return Redirect::to($autologin->getPath());
+			}
 		}
 
 		// Token was invalid, redirect back to the home page.


### PR DESCRIPTION
When users try to follow expired autologin links, the following warning is produced:

Undefined variable: user 
in vendor/watson/autologin/src/controllers/AutologinController.php at line 47

Initializing the variable before validating the ticket or checking if the variable is set would fix it.
