### PR TITLE
Laravel 5.1 support

### DIFF
--- a/src/Providers/EloquentAutologinProvider.php
+++ b/src/Providers/EloquentAutologinProvider.php
@@ -15,7 +15,7 @@ class EloquentAutologinProvider extends Model implements AutologinInterface {
      * @param  array  $attributes
      * @return \Watson\Autologin\Interfaces\AutologinInterface
      */
-    public static function create(array $attributes)
+    public static function create(array $attributes = [])
     {
         return parent::create($attributes);
     }
@@ -28,9 +28,9 @@ class EloquentAutologinProvider extends Model implements AutologinInterface {
      */
     public static function findByToken($token)
     {
-        return parent::firstByAttributes(array(
+		return parent::where(array(
             'token' => $token
-        ));
+        ))->first();
     }
 
     /**

--- a/src/Providers/EloquentAutologinProvider.php
+++ b/src/Providers/EloquentAutologinProvider.php
@@ -28,7 +28,7 @@ class EloquentAutologinProvider extends Model implements AutologinInterface {
      */
     public static function findByToken($token)
     {
-		return parent::where(array(
+        return parent::where(array(
             'token' => $token
         ))->first();
     }


### PR DESCRIPTION
* Eloquent's create method now needs default value of the $attributes parameter to an array:
* firstByAttributes() deprecated in Laravel 5.1 