### PR TITLE
Delete autologin if it is expired when user tries to login. 

### DIFF
--- a/src/Autologin.php
+++ b/src/Autologin.php
@@ -98,6 +98,17 @@ class Autologin
         $autologin = $this->provider->findByToken($token);
 
         if ($autologin) {
+
+            if (config('autologin.remove_expired')){
+
+                if($this->autologinTokenIsExpired($autologin->created_at))
+                {
+                    $autologin->delete();
+
+                    return null;
+                }
+            }
+
             if (config('autologin.count')) {
                 $autologin->incrementCount();
             }
@@ -183,5 +194,18 @@ class Autologin
     {
         return config('autologin.remove_expired')
             && random_int(1, config('autologin.lottery.1')) <= config('autologin.lottery.0');
+    }
+
+    /**
+     * Checks if the autologin token date is expired.
+     *
+     * @param  string  $date
+     * @return bool
+     */
+    protected function autologinTokenIsExpired($date)
+    {
+        $lifetime = config('autologin.lifetime');
+
+        return ( $date <= Carbon::now()->subMinutes($lifetime));
     }
 }


### PR DESCRIPTION
This code makes sure that when the user tries to autologin when the token is expired, it will delete the token and return null. 

->user clicks on autologin
->It checks if the config('autologin.remove_expired') is set to true.
->Then it checks if the autologin is expired.
->If it is, it will delete the autologin record in the database.